### PR TITLE
Added map merging and slice appending functionality.

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -59,7 +59,7 @@ type OperationForbiddenError struct {
 
 // Error implements error interface, stating that key was not found.
 func (e *OperationForbiddenError) Error() string {
-	return fmt.Sprintf("forbidden operation %s on key %s of type %s", OpNames[e.operation], e.key, e.keyType)
+	return fmt.Sprintf("forbidden operation %s on key %s of type %s", e.operation, e.key, e.keyType)
 }
 
 // Key returns the key that was operated on.

--- a/optikon.go
+++ b/optikon.go
@@ -1,4 +1,8 @@
+// Package optikon provides a way to manipulate deep Go structures using
+// simple relative path selectors.
 package optikon
+
+import "fmt"
 
 // OpType defines possible operation types.
 type OpType int
@@ -11,10 +15,17 @@ const (
 	DeleteOp OpType = 0x4
 )
 
-// OpNames provides readable names for operation types.
-var OpNames = map[OpType]string{
-	CreateOp: "Create",
-	UpdateOp: "Update",
-	SetOp:    "Set",
-	DeleteOp: "Delete",
+func (t OpType) String() string {
+	switch t {
+	case CreateOp:
+		return "Create"
+	case UpdateOp:
+		return "Update"
+	case SetOp:
+		return "Set"
+	case DeleteOp:
+		return "Delete"
+	default:
+		panic(fmt.Sprintf("operation type not known: %d", t))
+	}
 }

--- a/optikon.go
+++ b/optikon.go
@@ -5,14 +5,16 @@ type OpType int
 
 // OpType enumerates available operation types.
 const (
-	CreateOp OpType = iota + 1
-	UpdateOp
-	DeleteOp
+	CreateOp OpType = 0x1
+	UpdateOp OpType = 0x2
+	SetOp    OpType = CreateOp | UpdateOp
+	DeleteOp OpType = 0x4
 )
 
 // OpNames provides readable names for operation types.
 var OpNames = map[OpType]string{
 	CreateOp: "Create",
 	UpdateOp: "Update",
+	SetOp:    "Set",
 	DeleteOp: "Delete",
 }

--- a/select.go
+++ b/select.go
@@ -1,3 +1,5 @@
+// Implemenentation of partial data extraction for arbitrary Go
+// structures of any depth using relative path selectors.
 package optikon
 
 import (

--- a/update_test.go
+++ b/update_test.go
@@ -181,9 +181,11 @@ func TestUpdateMap(t *testing.T) {
 }
 
 func TestUpdateSlice(t *testing.T) {
+	strVal0 := "strVal0"
 	strVal1 := "strVal1"
 	strVal2 := "strVal2"
 
+	sliceVal0 := []string{strVal0}
 	sliceVal := []string{strVal1, strVal2}
 	arrVal := [2]string{strVal1, strVal2}
 	slicePtrVal := []*string{&strVal1, &strVal2}
@@ -192,12 +194,19 @@ func TestUpdateSlice(t *testing.T) {
 		"key1": strVal1,
 		"key2": strVal2,
 	}
+
+	mapSliceVal := map[string][]string{"key1": sliceVal0}
+	mapPtrSliceVal := map[string]*[]string{"key1": &sliceVal0}
+
 	sliceMapVal := []map[string]string{mapVal, mapVal}
 	slicePtrMapVal := []*map[string]string{&mapVal, &mapVal}
 	sliceSliceVal := [][]string{sliceVal, sliceVal}
 	slicePtrSliceVal := []*[]string{&sliceVal, &sliceVal}
 
-	td := &TypeDeep{}
+	td := &TypeDeep{
+		MapSliceVal:    mapSliceVal,
+		MapPtrSliceVal: mapPtrSliceVal,
+	}
 
 	data, _ := json.Marshal(arrVal)
 	err := UpdateJSON(td, []string{"arrVal"}, data, UpdateOp)
@@ -214,6 +223,16 @@ func TestUpdateSlice(t *testing.T) {
 	err = UpdateJSON(td, []string{"slicePtrVal"}, data, UpdateOp)
 	if assert.NoError(t, err) {
 		assert.EqualValues(t, slicePtrVal, td.SlicePtrVal)
+	}
+
+	err = UpdateJSON(td, []string{"mapSliceVal", "key1"}, data, UpdateOp)
+	if assert.NoError(t, err) {
+		assert.EqualValues(t, sliceVal, td.MapSliceVal["key1"])
+	}
+
+	err = UpdateJSON(td, []string{"mapPtrSliceVal", "key1"}, data, UpdateOp)
+	if assert.NoError(t, err) {
+		assert.EqualValues(t, &sliceVal, td.MapPtrSliceVal["key1"])
 	}
 
 	data, _ = json.Marshal(sliceMapVal)
@@ -355,22 +374,24 @@ func TestUpdateDeep(t *testing.T) {
 	strVal1 := "strVal1"
 	strVal2 := "strVal2"
 	intVal := 5
+
 	mapVal := map[string]string{
 		"key1": strVal1,
 		"key2": strVal2,
 	}
-	sliceVal := []string{strVal1, strVal2}
+
 	td1 := TypeDeep{
 		StrVal:    strVal1,
 		IntVal:    intVal,
 		MapVal:    mapVal,
 		PtrMapVal: &mapVal,
-		SliceVal:  sliceVal,
 	}
+
 	sliceDeep := []TypeDeep{td1, td1}
 	arrDeep := [2]TypeDeep{td1, td1}
 	slicePtrDeep := []*TypeDeep{&td1, &td1}
 	arrPtrDeep := [2]*TypeDeep{&td1, &td1}
+
 	mapDeep := map[string]TypeDeep{
 		"key1": td1,
 		"key2": td1,
@@ -773,7 +794,27 @@ func TestUpdateFails(t *testing.T) {
 }
 
 func TestCreateFails(t *testing.T) {
-	td := &TypeDeep{}
+	strVal0 := "strVal0"
+	strVal1 := "strVal1"
+	strVal2 := "strVal2"
+	sliceVal0 := []string{strVal0}
+	sliceSliceVal0 := [][]string{sliceVal0}
+	mapVal0 := map[string]string{
+		"key1": strVal1,
+		"key2": strVal2,
+	}
+	sliceMapVal0 := []map[string]string{mapVal0}
+	mapSliceVal0 := map[string][]string{"key1": sliceVal0}
+	mapMapVal0 := map[string]map[string]string{
+		"key0": mapVal0,
+	}
+
+	td := &TypeDeep{
+		SliceSliceVal: sliceSliceVal0,
+		SliceMapVal:   sliceMapVal0,
+		MapSliceVal:   mapSliceVal0,
+		MapMapVal:     mapMapVal0,
+	}
 
 	err := UpdateJSON(td, []string{"bogus"}, nil, CreateOp)
 	if assert.Error(t, err) {
@@ -797,75 +838,140 @@ func TestCreateFails(t *testing.T) {
 
 	err = UpdateJSON(td, []string{"sliceVal", "x"}, nil, CreateOp)
 	if assert.Error(t, err) {
-		assert.IsType(t, &KeyNotFoundError{}, err) // TODO: bad key results in KeyNotFoundError?
+		assert.IsType(t, &KeyNotFoundError{}, err)
 	}
 
+	data, _ := json.Marshal([]int{5, 6})
+	err = UpdateJSON(td, []string{"sliceVal"}, data, CreateOp)
+	if assert.Error(t, err) {
+		assert.IsType(t, &json.UnmarshalTypeError{}, err)
+	}
+
+	err = UpdateJSON(td, []string{"sliceSliceVal", "0"}, data, CreateOp)
+	if assert.Error(t, err) {
+		assert.IsType(t, &json.UnmarshalTypeError{}, err)
+	}
+
+	err = UpdateJSON(td, []string{"sliceMapVal", "0"}, data, CreateOp)
+	if assert.Error(t, err) {
+		assert.IsType(t, &OperationForbiddenError{}, err)
+	}
+
+	err = UpdateJSON(td, []string{"mapSliceVal", "key1"}, data, CreateOp)
+	if assert.Error(t, err) {
+		assert.IsType(t, &json.UnmarshalTypeError{}, err)
+	}
+
+	err = UpdateJSON(td, []string{"mapMapVal", "key0"}, data, CreateOp)
+	if assert.Error(t, err) {
+		assert.IsType(t, &KeyExistsError{}, err)
+	}
 }
 
 func TestCreateSuccessful(t *testing.T) {
+	strVal0 := "strVal0"
 	strVal1 := "strVal1"
 	strVal2 := "strVal2"
 	mapVal := map[string]string{
 		"key1": strVal1,
 		"key2": strVal2,
 	}
+
+	sliceVal0 := []string{strVal0}
 	sliceVal := []string{strVal1, strVal2}
+
+	slicePtrVal0 := []*string{&strVal0}
+	slicePtrVal := []*string{&strVal1, &strVal2}
+
 	arrVal := [2]string{strVal1, strVal2}
+
+	sliceMapVal0 := []map[string]string{mapVal}
 	sliceMapVal := []map[string]string{mapVal, mapVal}
+
+	slicePtrMapVal0 := []*map[string]string{&mapVal}
+	slicePtrMapVal := []*map[string]string{&mapVal, &mapVal}
+
+	sliceSliceVal0 := [][]string{sliceVal0}
 	sliceSliceVal := [][]string{sliceVal, sliceVal}
+
+	slicePtrSliceVal0 := []*[]string{&sliceVal}
+	slicePtrSliceVal := []*[]string{&sliceVal, &sliceVal}
+
+	sliceIntfVal0 := []interface{}{strVal0, 1}
 	sliceIntfVal := []interface{}{strVal1, 5.5}
+
 	var intfVal interface{} = sliceIntfVal
 
-	td := &TypeDeep{}
+	mapSliceVal0 := map[string][]string{"key1": sliceVal0}
+	mapPtrSliceVal0 := map[string]*[]string{"key1": &sliceVal0}
+
+	td := &TypeDeep{
+		SliceVal:         sliceVal0,
+		SlicePtrVal:      slicePtrVal0,
+		SliceMapVal:      sliceMapVal0,
+		SlicePtrMapVal:   slicePtrMapVal0,
+		SliceSliceVal:    sliceSliceVal0,
+		SlicePtrSliceVal: slicePtrSliceVal0,
+		SliceIntfVal:     sliceIntfVal0,
+		MapSliceVal:      mapSliceVal0,
+		MapPtrSliceVal:   mapPtrSliceVal0,
+	}
 
 	// One level.
 
 	data, _ := json.Marshal(sliceVal)
 	err := UpdateJSON(td, []string{"sliceVal"}, data, CreateOp)
 	if assert.NoError(t, err) {
-		assert.EqualValues(t, sliceVal, td.SliceVal)
+		assert.EqualValues(t, append(sliceVal0, sliceVal...), td.SliceVal)
 	}
 
 	err = UpdateJSON(td, []string{"slicePtrVal"}, data, CreateOp)
 	if assert.NoError(t, err) {
-		assert.Equal(t, &sliceVal[0], td.SlicePtrVal[0])
-		assert.Equal(t, &sliceVal[1], td.SlicePtrVal[1])
+		assert.EqualValues(t, append(slicePtrVal0, slicePtrVal...), td.SlicePtrVal)
 	}
 
 	data, _ = json.Marshal(sliceMapVal)
 	err = UpdateJSON(td, []string{"sliceMapVal"}, data, CreateOp)
 	if assert.NoError(t, err) {
-		assert.Equal(t, sliceMapVal[0], td.SliceMapVal[0])
-		assert.Equal(t, sliceMapVal[1], td.SliceMapVal[1])
+		assert.EqualValues(t, append(sliceMapVal0, sliceMapVal...), td.SliceMapVal)
 	}
 
 	err = UpdateJSON(td, []string{"slicePtrMapVal"}, data, CreateOp)
 	if assert.NoError(t, err) {
-		assert.Equal(t, &sliceMapVal[0], td.SlicePtrMapVal[0])
-		assert.Equal(t, &sliceMapVal[1], td.SlicePtrMapVal[1])
+		assert.EqualValues(t, append(slicePtrMapVal0, slicePtrMapVal...), td.SlicePtrMapVal)
 	}
 
 	data, _ = json.Marshal(sliceSliceVal)
 	err = UpdateJSON(td, []string{"sliceSliceVal"}, data, CreateOp)
 	if assert.NoError(t, err) {
-		assert.Equal(t, sliceSliceVal[0], td.SliceSliceVal[0])
-		assert.Equal(t, sliceSliceVal[1], td.SliceSliceVal[1])
+		assert.EqualValues(t, append(sliceSliceVal0, sliceSliceVal...), td.SliceSliceVal)
 	}
 
 	err = UpdateJSON(td, []string{"slicePtrSliceVal"}, data, CreateOp)
 	if assert.NoError(t, err) {
-		assert.Equal(t, &sliceSliceVal[0], td.SlicePtrSliceVal[0])
-		assert.Equal(t, &sliceSliceVal[1], td.SlicePtrSliceVal[1])
+		assert.EqualValues(t, append(slicePtrSliceVal0, slicePtrSliceVal...), td.SlicePtrSliceVal)
 	}
 
 	data, _ = json.Marshal(sliceIntfVal)
 	err = UpdateJSON(td, []string{"sliceIntfVal"}, data, CreateOp)
 	if assert.NoError(t, err) {
-		assert.Equal(t, sliceIntfVal[0], td.SliceIntfVal[0])
-		assert.Equal(t, sliceIntfVal[1], td.SliceIntfVal[1])
+		assert.EqualValues(t, append(sliceIntfVal0, sliceIntfVal...), td.SliceIntfVal)
 	}
 
 	// Two levels.
+
+	data, _ = json.Marshal(sliceVal)
+	err = UpdateJSON(td, []string{"sliceSliceVal", "0"}, data, CreateOp)
+	if assert.NoError(t, err) {
+		assert.EqualValues(t, append(sliceVal0, sliceVal...), td.SliceSliceVal[0])
+	}
+
+	/* TODO
+	err = UpdateJSON(td, []string{"slicePtrSliceVal", "0"}, data, CreateOp)
+	if assert.NoError(t, err) {
+		assert.EqualValues(t, append(sliceVal0, sliceVal...), td.SlicePtrSliceVal[0])
+	}
+	*/
 
 	data, _ = json.Marshal(mapVal)
 	err = UpdateJSON(td, []string{"mapMapVal", "new"}, data, CreateOp)
@@ -879,15 +985,17 @@ func TestCreateSuccessful(t *testing.T) {
 	}
 
 	data, _ = json.Marshal(sliceVal)
-	err = UpdateJSON(td, []string{"mapSliceVal", "new"}, data, CreateOp)
+	err = UpdateJSON(td, []string{"mapSliceVal", "key1"}, data, CreateOp)
 	if assert.NoError(t, err) {
-		assert.EqualValues(t, sliceVal, td.MapSliceVal["new"])
+		assert.EqualValues(t, append(sliceVal0, sliceVal...), td.MapSliceVal["key1"])
 	}
 
-	err = UpdateJSON(td, []string{"mapPtrSliceVal", "new"}, data, CreateOp)
+	/* TODO
+	err = UpdateJSON(td, []string{"mapPtrSliceVal", "key1"}, data, CreateOp)
 	if assert.NoError(t, err) {
-		assert.EqualValues(t, &sliceVal, td.MapPtrSliceVal["new"])
+		assert.EqualValues(t, &sliceVal, td.MapPtrSliceVal["key1"])
 	}
+	*/
 
 	err = UpdateJSON(td, []string{"mapArrVal", "new"}, data, CreateOp)
 	if assert.NoError(t, err) {
@@ -900,6 +1008,91 @@ func TestCreateSuccessful(t *testing.T) {
 		assert.EqualValues(t, intfVal, td.MapIntfVal["new"])
 	}
 
+}
+
+func TestSetSuccessful(t *testing.T) {
+	strVal0 := "strVal0"
+	strVal1 := "strVal1"
+	strVal2 := "strVal2"
+
+	mapVal0 := map[string]string{
+		"key0": strVal0,
+	}
+	mapVal := map[string]string{
+		"key1": strVal1,
+		"key2": strVal2,
+	}
+
+	sliceMapVal0 := []map[string]string{mapVal0}
+	mapMapVal0 := map[string]map[string]string{
+		"key0": mapVal0,
+	}
+
+	td := &TypeDeep{
+		MapVal:      mapVal0,
+		SliceMapVal: sliceMapVal0,
+		MapMapVal:   mapMapVal0,
+	}
+
+	data, _ := json.Marshal(mapVal)
+	err := UpdateJSON(td, []string{"mapVal"}, data, SetOp)
+	if assert.NoError(t, err) && assert.Equal(t, 3, len(td.MapVal)) {
+		assert.Equal(t, mapVal0["key0"], td.MapVal["key0"])
+		assert.Equal(t, mapVal["key1"], td.MapVal["key1"])
+		assert.Equal(t, mapVal["key2"], td.MapVal["key2"])
+	}
+
+	err = UpdateJSON(td, []string{"sliceMapVal", "0"}, data, SetOp)
+	if assert.NoError(t, err) && assert.Equal(t, 3, len(td.SliceMapVal[0])) {
+		assert.Equal(t, mapVal0["key0"], td.SliceMapVal[0]["key0"])
+		assert.Equal(t, mapVal["key1"], td.SliceMapVal[0]["key1"])
+		assert.Equal(t, mapVal["key2"], td.SliceMapVal[0]["key2"])
+	}
+
+	err = UpdateJSON(td, []string{"mapMapVal", "key0"}, data, SetOp)
+	if assert.NoError(t, err) && assert.Equal(t, 3, len(td.MapMapVal["key0"])) {
+		assert.Equal(t, mapVal0["key0"], td.MapMapVal["key0"]["key0"])
+		assert.Equal(t, mapVal["key1"], td.MapMapVal["key0"]["key1"])
+		assert.Equal(t, mapVal["key2"], td.MapMapVal["key0"]["key2"])
+	}
+}
+
+func TestSetFails(t *testing.T) {
+	//strVal0 := "strVal0"
+	strVal1 := "strVal1"
+	strVal2 := "strVal2"
+	//sliceVal0 := []string{strVal0}
+	//sliceSliceVal0 := [][]string{sliceVal0}
+	mapVal := map[string]string{
+		"key1": strVal1,
+		"key2": strVal2,
+	}
+	sliceMapVal0 := []map[string]string{mapVal}
+	mapMapVal0 := map[string]map[string]string{
+		"key0": mapVal,
+	}
+
+	td := &TypeDeep{
+		MapVal:      mapVal,
+		SliceMapVal: sliceMapVal0,
+		MapMapVal:   mapMapVal0,
+	}
+
+	data, _ := json.Marshal([]int{5, 6})
+	err := UpdateJSON(td, []string{"mapVal"}, data, SetOp)
+	if assert.Error(t, err) {
+		assert.IsType(t, &json.UnmarshalTypeError{}, err)
+	}
+
+	err = UpdateJSON(td, []string{"sliceMapVal", "0"}, data, SetOp)
+	if assert.Error(t, err) {
+		assert.IsType(t, &json.UnmarshalTypeError{}, err)
+	}
+
+	err = UpdateJSON(td, []string{"mapMapVal", "key0"}, data, SetOp)
+	if assert.Error(t, err) {
+		assert.IsType(t, &json.UnmarshalTypeError{}, err)
+	}
 }
 
 func TestDeleteFails(t *testing.T) {

--- a/update_test.go
+++ b/update_test.go
@@ -747,7 +747,7 @@ func TestUpdateFails(t *testing.T) {
 		"key1": strVal1,
 		"key2": strVal2,
 	}
-	td := TypeDeep{}
+	td := &TypeDeep{}
 
 	err := UpdateJSON(td, []string{"bogus"}, nil, UpdateOp)
 	if assert.Error(t, err) {
@@ -761,7 +761,7 @@ func TestUpdateFails(t *testing.T) {
 
 	err = UpdateJSON(td, []string{"strVal"}, json.RawMessage("strVal"), UpdateOp)
 	if assert.Error(t, err) {
-		//assert.IsType(t, &OperationForbiddenError{}, err) // TODO
+		assert.IsType(t, &json.SyntaxError{}, err) // TODO
 	}
 
 	err = UpdateJSON(td, []string{"sliceVal", "x"}, nil, UpdateOp)
@@ -774,8 +774,9 @@ func TestUpdateFails(t *testing.T) {
 		assert.IsType(t, &KeyNotFoundError{}, err)
 	}
 
-	// TODO: update on empty map results in keynotfound error? Or results in create?
-	//err = UpdateJSON(td, []string{"mapVal"}, `{"key1":"bogus"}`, UpdateOp)
+	// TODO: update on empty map to result in KeyNotFoundError? Currently works as Create.
+	//data, _ := json.Marshal(mapVal)
+	//err = UpdateJSON(td, []string{"mapVal"}, data, UpdateOp)
 	//if assert.Error(t, err) {
 	//	assert.IsType(t, &KeyNotFoundError{}, err)
 	//}
@@ -966,7 +967,7 @@ func TestCreateSuccessful(t *testing.T) {
 		assert.EqualValues(t, append(sliceVal0, sliceVal...), td.SliceSliceVal[0])
 	}
 
-	/* TODO
+	/* TODO: handle pointers to slices.
 	err = UpdateJSON(td, []string{"slicePtrSliceVal", "0"}, data, CreateOp)
 	if assert.NoError(t, err) {
 		assert.EqualValues(t, append(sliceVal0, sliceVal...), td.SlicePtrSliceVal[0])
@@ -990,7 +991,7 @@ func TestCreateSuccessful(t *testing.T) {
 		assert.EqualValues(t, append(sliceVal0, sliceVal...), td.MapSliceVal["key1"])
 	}
 
-	/* TODO
+	/* TODO: handle pointers to slices.
 	err = UpdateJSON(td, []string{"mapPtrSliceVal", "key1"}, data, CreateOp)
 	if assert.NoError(t, err) {
 		assert.EqualValues(t, &sliceVal, td.MapPtrSliceVal["key1"])
@@ -1058,11 +1059,8 @@ func TestSetSuccessful(t *testing.T) {
 }
 
 func TestSetFails(t *testing.T) {
-	//strVal0 := "strVal0"
 	strVal1 := "strVal1"
 	strVal2 := "strVal2"
-	//sliceVal0 := []string{strVal0}
-	//sliceSliceVal0 := [][]string{sliceVal0}
 	mapVal := map[string]string{
 		"key1": strVal1,
 		"key2": strVal2,
@@ -1342,6 +1340,8 @@ func TestDeleteSuccessful(t *testing.T) {
 
 	// Two levels.
 
+	// TODO: can actually handle deleting indexed elements in the slice, but the
+	// delete should probably be done by value and not by index.
 	//err = UpdateJSON(td, []string{"sliceIntfVal", "0"}, nil, DeleteOp)
 	//if assert.NoError(t, err) {
 	//	assert.Equal(t, 1, len(td.SliceIntfVal))
@@ -1393,5 +1393,4 @@ func TestDeleteSuccessful(t *testing.T) {
 		_, ok := td.MapPtrDeep["key2"].MapVal["key2"]
 		assert.False(t, ok)
 	}
-
 }


### PR DESCRIPTION
@fuzzyami @oryband 

optikon now includes the following functionality:
- specifying CreateOp on slice will append input slice to the original slice
- specifying UpdateOp on slice will replace the slice with new values
- specifying SetOp on map will merge input map with the original map
- specifying UpdateOp on map will replace the map

There's a possibility that it will break something, so please check before we merge.

Earlier commit (merged, non breaking) enabled direct setting of single struct fields, map keys and slice elements.

also reached 100% coverage.